### PR TITLE
Support eslint v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "eslint": ">= 3.3.0 < 6.0.0",
+    "eslint": ">= 3.3.0 < 5.0.0",
     "eslint-config-pedant": "^1.0.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "node": ">= 4"
   },
   "peerDependencies": {
-    "eslint": ">= 3.3.0"
+    "eslint": ">= 3.3.0 < 6.0.0"
   },
   "dependencies": {},
   "devDependencies": {
-    "eslint": ">= 3.3.0",
-    "eslint-config-pedant": "^0.10.0"
+    "eslint": ">= 3.3.0 < 6.0.0",
+    "eslint-config-pedant": "^1.0.1"
   },
   "scripts": {
     "test": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "node": ">= 4"
   },
   "peerDependencies": {
-    "eslint": ">= 3.3.0 < 5.0.0"
+    "eslint": ">= 3.3.0"
   },
   "dependencies": {},
   "devDependencies": {
-    "eslint": ">= 3.3.0 < 5.0.0",
+    "eslint": ">= 3.3.0",
     "eslint-config-pedant": "^0.10.0"
   },
   "scripts": {


### PR DESCRIPTION
Уже вышел Eslint v5, на первый взгляд bem-xjst/bemhtml и bem-xjst/bemtree отрабатывают корректно и на 5-той версии.
Можно ли снять ограничение на версию? Сейчас это приводит к невозможности использовать пакет на актуальном Eslint.